### PR TITLE
disallowing rotate recovery

### DIFF
--- a/launch/move_base.launch
+++ b/launch/move_base.launch
@@ -5,6 +5,7 @@
     <param name="controller_frequency" value="10.0" />
     <param name="controller_patience" value="15.0" />
     <param name="planner_frequency" value="2.0" />
+    <param name="clearing_rotation_allowed" value="false" />
     <rosparam file="$(find scitos_2d_navigation)/scitos_move_base_params/costmap_common_params.yaml" command="load" ns="global_costmap" />
     <rosparam file="$(find scitos_2d_navigation)/scitos_move_base_params/costmap_common_params.yaml" command="load" ns="local_costmap" />
     <rosparam file="$(find scitos_2d_navigation)/scitos_move_base_params/local_costmap_params.yaml" command="load" />


### PR DESCRIPTION
This does not disable the costmap clearing, it just makes the robot stop trying to rotate, which can cause problems to recover from bumper hit or stuck in carpet situations - see https://github.com/strands-project/autonomous_patrolling/issues/27
