### PR TITLE
This adds a cliff sensor to the 2d navigation stack with camera

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ project(scitos_2d_navigation)
 ## Find catkin macros and libraries
 ## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)
 ## is used, also find other catkin packages
-find_package(catkin REQUIRED roscpp sensor_msgs std_msgs pcl_ros)
+find_package(catkin REQUIRED roscpp sensor_msgs std_msgs pcl_ros tf)
 
 ## System dependencies are found with CMake's conventions
 # find_package(Boost REQUIRED COMPONENTS system)
@@ -76,6 +76,7 @@ add_library(noise_approximate_voxel_grid src/noise_approximate_voxel_grid.cpp)
 ## Declare a cpp executable
 add_executable(subsample_cloud src/subsample_cloud.cpp)
 add_executable(remove_edges_cloud src/remove_edges_cloud.cpp)
+add_executable(mirror_floor_points src/mirror_floor_points.cpp)
 
 ## Add cmake target dependencies of the executable/library
 ## as an example, message headers may need to be generated before nodes
@@ -90,6 +91,10 @@ target_link_libraries(subsample_cloud
 )
 
 target_link_libraries(remove_edges_cloud
+  ${catkin_LIBRARIES} ${PCL_LIBRARIES}
+)
+
+target_link_libraries(mirror_floor_points
   ${catkin_LIBRARIES} ${PCL_LIBRARIES}
 )
 

--- a/launch/move_base_3d.launch
+++ b/launch/move_base_3d.launch
@@ -18,10 +18,17 @@
         <param name="input" value="$(arg camera)/depth/points"/>
         <param name="output" value="/move_base/points_subsampled"/>
     </node>
+    
+    <!-- This node downsamples cloud and removes voxels with too few points in them -->
+    <node pkg="scitos_2d_navigation" type="mirror_floor_points" name="mirror_floor_points" output="screen">
+        <param name="input" value="/move_base/points_subsampled"/>
+        <param name="obstacle_output" value="/move_base/points_clearing"/>
+        <param name="floor_output" value="/move_base/points_cliff"/>
+    </node>
 
     <!-- This node removes the desired cutoff pixels from the cloud edges -->
     <node pkg="scitos_2d_navigation" type="remove_edges_cloud" name="remove_edges_cloud" output="screen">
-        <param name="input" value="/move_base/points_subsampled"/>
+        <param name="input" value="/move_base/points_clearing"/>
         <param name="output" value="/move_base/points_obstacle"/>
         <param name="cutoff" value="50.0"/>
         <param name="cutoff_z" value="0.3"/>

--- a/launch/move_base_3d.launch
+++ b/launch/move_base_3d.launch
@@ -19,12 +19,14 @@
         <param name="output" value="/move_base/points_subsampled"/>
     </node>
     
-    <!-- This node downsamples cloud and removes voxels with too few points in them -->
+    <!-- This node divides into points below and above the floor -->
     <node pkg="scitos_2d_navigation" type="mirror_floor_points" name="mirror_floor_points" output="screen">
         <param name="input" value="/move_base/points_subsampled"/>
         <param name="obstacle_output" value="/move_base/points_clearing"/>
         <param name="floor_output" value="/move_base/points_cliff"/>
         <param name="camera_frame" value="chest_xtion_rgb_optical_frame"/>
+        <!-- Distance below floor that's counted as stair -->
+        <param name="below_threshold" value="0.05"/>
     </node>
 
     <!-- This node removes the desired cutoff pixels from the cloud edges -->

--- a/launch/move_base_3d.launch
+++ b/launch/move_base_3d.launch
@@ -24,6 +24,7 @@
         <param name="input" value="/move_base/points_subsampled"/>
         <param name="obstacle_output" value="/move_base/points_clearing"/>
         <param name="floor_output" value="/move_base/points_cliff"/>
+        <param name="camera_frame" value="chest_xtion_rgb_optical_frame"/>
     </node>
 
     <!-- This node removes the desired cutoff pixels from the cloud edges -->

--- a/package.xml
+++ b/package.xml
@@ -35,11 +35,13 @@
   <build_depend>std_msgs</build_depend>
   <build_depend>pcl_ros</build_depend>
   <build_depend>libpcl-all-dev</build_depend>
+  <build_depend>tf</build_depend>
   <run_depend>sensor_msgs</run_depend>
   <run_depend>roscpp</run_depend>
   <run_depend>std_msgs</run_depend>
   <run_depend>pcl_ros</run_depend>
   <run_depend>libpcl-all</run_depend>
+  <run_depend>tf</run_depend>
 
   <!-- The export tag contains other, unspecified, tags -->
   <export>

--- a/scitos_move_base_params_3d/costmap_common_params.yaml
+++ b/scitos_move_base_params_3d/costmap_common_params.yaml
@@ -31,13 +31,15 @@ obstacle_layer:
   unknown_threshold: 6
   mark_threshold: 0
   
-  observation_sources: laser point_cloud_sensor clear_sensor
+  observation_sources: laser point_cloud_sensor clear_sensor cliff_sensor
   
   laser: {sensor_frame: base_laser_link, data_type: LaserScan, topic: scan, marking: true, clearing: true}
   
   point_cloud_sensor: {topic: /move_base/points_obstacle, data_type: PointCloud2, marking: true, clearing: false, min_obstacle_height: 0.1, max_obstacle_height: 0.9, observation_persistence: 0.0, obstacle_range: 2.0}
 
-  clear_sensor: {topic: /move_base/points_subsampled, data_type: PointCloud2, marking: false, clearing: true, min_obstacle_height: -0.1, max_obstacle_height: 1.1, observation_persistence: 0.0, raytrace_range: 4.0}
+  clear_sensor: {topic: /move_base/points_clearing, data_type: PointCloud2, marking: false, clearing: true, min_obstacle_height: -0.1, max_obstacle_height: 1.1, observation_persistence: 0.0, raytrace_range: 4.0}
+  
+  cliff_sensor: {topic: /move_base/points_cliff, data_type: PointCloud2, marking: true, clearing: false, min_obstacle_height: 0.1, max_obstacle_height: 0.15, observation_persistence: 0.0, obstacle_range: 3.0}
 
   wall_cloud: {topic: /move_base/clear_wall, sensor_frame: /chest_xtion_depth_optical_frame, data_type: PointCloud2, marking: false, clearing: true, observation_persistence: 0.0, raytrace_range: 2.80}
 

--- a/src/mirror_floor_points.cpp
+++ b/src/mirror_floor_points.cpp
@@ -54,13 +54,13 @@ void callback(const sensor_msgs::PointCloud2::ConstPtr& msg)
 
 	sensor_msgs::PointCloud2 floor_msg;
     pcl::toROSMsg(*floor_cloud, floor_msg);
-	floor_msg.header.frame_id = msg->header.frame_id;
+	floor_msg.header = msg->header;
 
 	floor_pub.publish(floor_msg);
 	
 	sensor_msgs::PointCloud2 obstacle_msg;
     pcl::toROSMsg(*obstacle_cloud, obstacle_msg);
-	obstacle_msg.header.frame_id = msg->header.frame_id;
+	obstacle_msg.header = msg->header;
 	
 	obstacle_pub.publish(obstacle_msg);
 }

--- a/src/mirror_floor_points.cpp
+++ b/src/mirror_floor_points.cpp
@@ -1,0 +1,97 @@
+#include <ros/ros.h>
+#include <sensor_msgs/PointCloud2.h>
+#include <pcl_ros/point_cloud.h>
+#include <pcl/point_types.h>
+#include <boost/thread/thread.hpp>
+#include <tf/transform_listener.h>
+#include <Eigen/Dense>
+
+ros::Publisher pub;
+
+double height;
+Eigen::Vector3d normal;
+
+void callback(const sensor_msgs::PointCloud2::ConstPtr& msg)
+{
+    pcl::PointCloud<pcl::PointXYZ>::Ptr cloud(new pcl::PointCloud<pcl::PointXYZ>());
+    pcl::fromROSMsg(*msg, *cloud);
+	
+	for (size_t i = 0; i < cloud->size(); ++i) {
+	    
+	}
+
+	sensor_msgs::PointCloud2 msg_cloud;
+    pcl::toROSMsg(voxel_cloud, msg_cloud);
+	msg_cloud.header.frame_id = msg->header.frame_id;
+
+	pub.publish(msg_cloud);
+}
+
+int main(int argc, char** argv)
+{
+    ros::init(argc, argv, "subsample_cloud");
+	ros::NodeHandle n;
+	
+	ros::NodeHandle pn("~");
+    // topic of input cloud
+    if (!pn.hasParam("input")) {
+        ROS_ERROR("Could not find parameter input.");
+        return -1;
+    }
+    std::string input;
+    pn.getParam("input", input);
+    
+    // topic of output cloud
+    if (!pn.hasParam("obstacle_output")) {
+        ROS_ERROR("Could not find parameter obstacle_output.");
+        return -1;
+    }
+    std::string obstacle_output;
+    pn.getParam("obstacle_output", obstacle_output);
+    
+    // topic of output cloud
+    if (!pn.hasParam("camera_frame")) {
+        ROS_ERROR("Could not find parameter camera_frame.");
+        return -1;
+    }
+    std::string camera_frame;
+    pn.getParam("camera_frame", camera_frame);
+    
+    // topic of output cloud
+    if (!pn.hasParam("floor_output")) {
+        ROS_ERROR("Could not find parameter floor_output.");
+        return -1;
+    }
+    std::string floor_output;
+    pn.getParam("floor_output", floor_output);
+    
+	ros::Subscriber sub = n.subscribe(input, 1, callback);
+    pub = n.advertise<sensor_msgs::PointCloud2>(output, 1);
+    
+    tf::TransformListener listener;
+    geometry_msgs::PointStamped pout;
+    geometry_msgs::PointStamped pin;
+    pin.point.x = 0; pin.point.y = 0; pin.point.z = 0;
+    geometry_msgs::Vector3Stamped vout;
+    geometry_msgs::Vector3Stamped vin;
+    vin.vector.x = 0; vin.vector.y = 0; vin.vector.z = 1;
+    
+    ros::Rate rate(0.05); // updating at 5 hz, slightly faster than move_base
+    while (n.ok()) {
+        tf::StampedTransform transform;
+        try {
+            listener.lookupTransform("/base_link", camera_frame, ros::Time(0), transform);
+            transform.transformPoint(camera_frame, ros::Time(0), pin, "/base_link", pout);
+            height = pout.point.z;
+            transform.transformVector3(camera_frame, ros::Time(0), vin, "/base_link", vout);
+            normal = Eigen::Vector3d(vout.vector.x, vout.vector.y, vout.vector.z);
+        }
+        catch (tf::TransformException ex) {
+            ROS_ERROR("%s",ex.what());
+        }
+        rate.sleep();
+        ros::spinOnce();
+    }
+	
+	return 0;
+}

--- a/src/remove_edges_cloud.cpp
+++ b/src/remove_edges_cloud.cpp
@@ -37,7 +37,7 @@ void callback(const sensor_msgs::PointCloud2::ConstPtr& msg)
 
 	sensor_msgs::PointCloud2 msg_cloud;
     pcl::toROSMsg(new_cloud, msg_cloud);
-	msg_cloud.header.frame_id = msg->header.frame_id;
+	msg_cloud.header = msg->header;
 	pub.publish(msg_cloud);
 }
 

--- a/src/subsample_cloud.cpp
+++ b/src/subsample_cloud.cpp
@@ -28,7 +28,7 @@ void callback(const sensor_msgs::PointCloud2::ConstPtr& msg)
 
 	sensor_msgs::PointCloud2 msg_cloud;
     pcl::toROSMsg(voxel_cloud, msg_cloud);
-	msg_cloud.header.frame_id = msg->header.frame_id;
+	msg_cloud.header = msg->header;
 
 	pub.publish(msg_cloud);
 }


### PR DESCRIPTION
This adds a new sensor input, cliff_sensor, which is basically points below a certain threshold below the floor projected towards the camera into the ground plane and then elevated to be slightly above the floor. This enables them to be cleared by observing a ground plane below (that is not below the threshold), something that is probably necessary to deal with sensor noise. Note that the threshold is currently set at 5cm which seems to be enough for our stairs, this can be configured in `move_base_3d.launch`.

We have done tests with 3 different stairs of 2 different types and the robot picks them up and doesn't plan down them. For the deployment at AAF, it would be good if Tomas and Michael can test with the stairs there. Look at the local obstacle map and see that there really are obstacles there and see if the detected stair points are in `/move_base/points_cliff`.

I've added a new node, `mirror_floor_points`, which basically does all of the dirty work, it separates the points below from the points above and reprojects the points below to the ground plane. It then publishes these two as separate topics, `/move_base/points_clearing` and `/move_base/points_cliff`. This doesn't seem to have a big influence of performance as it's taking up ~2% CPU on our robot.
