### PR TITLE
This adds an extra obstacle layer in the local costmap that can be used for backtracking

### DIFF
--- a/launch/move_base_3d.launch
+++ b/launch/move_base_3d.launch
@@ -26,6 +26,14 @@
         <param name="cutoff" value="50.0"/>
         <param name="cutoff_z" value="0.3"/>
     </node>
+    
+    <!-- This node removes the desired cutoff pixels from the head cloud edges -->
+    <node pkg="scitos_2d_navigation" type="remove_edges_cloud" name="remove_edges_cloud_head" output="screen">
+        <param name="input" value="/move_base/head_subsampled"/>
+        <param name="output" value="/move_base/head_obstacle"/>
+        <param name="cutoff" value="50.0"/>
+        <param name="cutoff_z" value="0.3"/>
+    </node>
 
     <!-- This node adds a synthetic wall at the edge of raytrace range to remove high objects -->
     <!--

--- a/launch/move_base_3d.launch
+++ b/launch/move_base_3d.launch
@@ -33,7 +33,6 @@
         <param name="input" value="/move_base/head_subsampled"/>
         <param name="obstacle_output" value="/move_base/head_clearing"/>
         <param name="floor_output" value="/move_base/head_cliff"/>
-        <param name="camera_frame" value="head_xtion_rgb_optical_frame"/>
         <!-- Distance below floor that's counted as stair -->
         <param name="below_threshold" value="0.05"/>
     </node>

--- a/launch/move_base_3d.launch
+++ b/launch/move_base_3d.launch
@@ -34,7 +34,6 @@
         <param name="input" value="/move_base/head_subsampled"/>
         <param name="obstacle_output" value="/move_base/head_clearing"/>
         <param name="floor_output" value="/move_base/head_cliff"/>
-        <!-- Distance below floor that's counted as stair -->
         <param name="below_threshold" value="0.05"/>
     </node>
     -->

--- a/launch/move_base_3d.launch
+++ b/launch/move_base_3d.launch
@@ -29,6 +29,7 @@
     </node>
     
     <!-- This node divides into points below and above the floor -->
+    <!--
     <node pkg="scitos_2d_navigation" type="mirror_floor_points" name="mirror_floor_points_head" output="screen">
         <param name="input" value="/move_base/head_subsampled"/>
         <param name="obstacle_output" value="/move_base/head_clearing"/>
@@ -36,6 +37,7 @@
         <!-- Distance below floor that's counted as stair -->
         <param name="below_threshold" value="0.05"/>
     </node>
+    -->
 
     <!-- This node removes the desired cutoff pixels from the cloud edges -->
     <node pkg="scitos_2d_navigation" type="remove_edges_cloud" name="remove_edges_cloud" output="screen">
@@ -47,7 +49,7 @@
     
     <!-- This node removes the desired cutoff pixels from the head cloud edges -->
     <node pkg="scitos_2d_navigation" type="remove_edges_cloud" name="remove_edges_cloud_head" output="screen">
-        <param name="input" value="/move_base/head_clearing"/>
+        <param name="input" value="/move_base/head_subsampled"/>
         <param name="output" value="/move_base/head_obstacle"/>
         <param name="cutoff" value="50.0"/>
         <param name="cutoff_z" value="0.3"/>

--- a/scitos_move_base_params_3d/costmap_common_params.yaml
+++ b/scitos_move_base_params_3d/costmap_common_params.yaml
@@ -43,9 +43,9 @@ obstacle_layer:
 
   wall_cloud: {topic: /move_base/clear_wall, sensor_frame: /chest_xtion_depth_optical_frame, data_type: PointCloud2, marking: false, clearing: true, observation_persistence: 0.0, raytrace_range: 2.80}
   
-  head_cloud_sensor: {topic: /move_base/head_obstacle, data_type: PointCloud2, marking: true, clearing: false, min_obstacle_height: 0.1, max_obstacle_height: 1.6, observation_persistence: 0.0, obstacle_range: 2.0}
+  head_cloud_sensor: {topic: /move_base/head_obstacle, data_type: PointCloud2, marking: true, clearing: false, min_obstacle_height: 0.1, max_obstacle_height: 1.1, observation_persistence: 0.0, obstacle_range: 2.0}
 
-  head_clear_sensor: {topic: /move_base/head_clearing, data_type: PointCloud2, marking: false, clearing: true, min_obstacle_height: -0.1, max_obstacle_height: 1.7, observation_persistence: 0.0, raytrace_range: 4.0}
+  head_clear_sensor: {topic: /move_base/head_clearing, data_type: PointCloud2, marking: false, clearing: true, min_obstacle_height: -0.1, max_obstacle_height: 1.0, observation_persistence: 0.0, raytrace_range: 4.0}
   
   head_cliff_sensor: {topic: /move_base/head_cliff, data_type: PointCloud2, marking: true, clearing: false, min_obstacle_height: 0.1, max_obstacle_height: 0.15, observation_persistence: 0.0, obstacle_range: 3.0}
 

--- a/scitos_move_base_params_3d/costmap_common_params.yaml
+++ b/scitos_move_base_params_3d/costmap_common_params.yaml
@@ -32,9 +32,9 @@ head_obstacle_layer:
   
   observation_sources: head_cloud_sensor head_clear_sensor head_cliff_sensor
   
-  head_cloud_sensor: {topic: /move_base/head_obstacle, data_type: PointCloud2, marking: true, clearing: false, min_obstacle_height: 0.2, max_obstacle_height: 1.0, observation_persistence: 0.0, obstacle_range: 2.0}
+  head_cloud_sensor: {topic: /move_base/head_obstacle, data_type: PointCloud2, marking: true, clearing: false, min_obstacle_height: 0.2, max_obstacle_height: 1.3, observation_persistence: 0.0, obstacle_range: 2.0}
 
-  head_clear_sensor: {topic: /move_base/head_subsampled, data_type: PointCloud2, marking: false, clearing: true, min_obstacle_height: -0.1, max_obstacle_height: 1.1, observation_persistence: 0.0, raytrace_range: 4.0}
+  head_clear_sensor: {topic: /move_base/head_subsampled, data_type: PointCloud2, marking: false, clearing: true, min_obstacle_height: -0.1, max_obstacle_height: 1.4, observation_persistence: 0.0, raytrace_range: 4.0}
   
 #  head_cliff_sensor: {topic: /move_base/head_cliff, data_type: PointCloud2, marking: true, clearing: false, min_obstacle_height: 0.1, max_obstacle_height: 0.15, observation_persistence: 0.0, obstacle_range: 3.0}
   

--- a/scitos_move_base_params_3d/costmap_common_params.yaml
+++ b/scitos_move_base_params_3d/costmap_common_params.yaml
@@ -31,7 +31,7 @@ obstacle_layer:
   unknown_threshold: 9
   mark_threshold: 0
   
-  observation_sources: laser point_cloud_sensor clear_sensor
+  observation_sources: laser point_cloud_sensor clear_sensor head_cloud_sensor head_clear_sensor
   
   laser: {sensor_frame: base_laser_link, data_type: LaserScan, topic: scan, marking: true, clearing: true}
   

--- a/scitos_move_base_params_3d/costmap_common_params.yaml
+++ b/scitos_move_base_params_3d/costmap_common_params.yaml
@@ -1,7 +1,7 @@
 global_frame: /map
 robot_base_frame: /base_link
 
-  
+
 map_type: voxel
 publish_voxel_map: true
 
@@ -41,10 +41,10 @@ obstacle_layer:
 
   wall_cloud: {topic: /move_base/clear_wall, sensor_frame: /chest_xtion_depth_optical_frame, data_type: PointCloud2, marking: false, clearing: true, observation_persistence: 0.0, raytrace_range: 2.80}
   
-  head_cloud_sensor: {topic: /move_base/head_obstacle, data_type: PointCloud2, marking: true, clearing: false, min_obstacle_height: 0.1, max_obstacle_height: 0.9, observation_persistence: 0.0, obstacle_range: 2.0}
+  head_cloud_sensor: {topic: /move_base/head_obstacle, data_type: PointCloud2, marking: true, clearing: false, min_obstacle_height: 0.1, max_obstacle_height: 1.6, observation_persistence: 0.0, obstacle_range: 2.0}
 
-  head_clear_sensor: {topic: /move_base/head_subsampled, data_type: PointCloud2, marking: false, clearing: true, min_obstacle_height: -0.1, max_obstacle_height: 1.6, observation_persistence: 0.0, raytrace_range: 4.0}
-  
+  head_clear_sensor: {topic: /move_base/head_subsampled, data_type: PointCloud2, marking: false, clearing: true, min_obstacle_height: -0.1, max_obstacle_height: 1.7, observation_persistence: 0.0, raytrace_range: 4.0}
+
 #point_cloud_sensor: {sensor_frame: camera_link, data_type: PointCloud2, topic: /camera/depth/points, marking: true, clearing: true}
 
 

--- a/scitos_move_base_params_3d/costmap_common_params.yaml
+++ b/scitos_move_base_params_3d/costmap_common_params.yaml
@@ -18,10 +18,9 @@ no_go_layer:
 inflation_layer:
   inflation_radius: 0.8
   cost_scaling_factor: 10.0
-    
 
-obstacle_layer:
-  max_obstacle_height: 1.6
+head_obstacle_layer:    
+  max_obstacle_height: 2.0
   obstacle_range: 2.5
   raytrace_range: 3.0
   
@@ -29,6 +28,25 @@ obstacle_layer:
   z_resolution: 0.2
   z_voxels: 9
   unknown_threshold: 9
+  mark_threshold: 0
+  
+  observation_sources: head_cloud_sensor head_clear_sensor head_cliff_sensor
+  
+  head_cloud_sensor: {topic: /move_base/head_obstacle, data_type: PointCloud2, marking: true, clearing: false, min_obstacle_height: 0.1, max_obstacle_height: 1.1, observation_persistence: 0.0, obstacle_range: 2.0}
+
+  head_clear_sensor: {topic: /move_base/head_clearing, data_type: PointCloud2, marking: false, clearing: true, min_obstacle_height: -0.1, max_obstacle_height: 1.0, observation_persistence: 0.0, raytrace_range: 4.0}
+  
+  head_cliff_sensor: {topic: /move_base/head_cliff, data_type: PointCloud2, marking: true, clearing: false, min_obstacle_height: 0.1, max_obstacle_height: 0.15, observation_persistence: 0.0, obstacle_range: 3.0}
+  
+obstacle_layer:
+  max_obstacle_height: 2.0
+  obstacle_range: 2.5
+  raytrace_range: 3.0
+  
+  origin_z: -0.08
+  z_resolution: 0.2
+  z_voxels: 6
+  unknown_threshold: 6
   mark_threshold: 0
   
   observation_sources: laser point_cloud_sensor clear_sensor cliff_sensor head_cloud_sensor head_clear_sensor head_cliff_sensor
@@ -40,16 +58,6 @@ obstacle_layer:
   clear_sensor: {topic: /move_base/points_clearing, data_type: PointCloud2, marking: false, clearing: true, min_obstacle_height: -0.1, max_obstacle_height: 1.1, observation_persistence: 0.0, raytrace_range: 4.0}
   
   cliff_sensor: {topic: /move_base/points_cliff, data_type: PointCloud2, marking: true, clearing: false, min_obstacle_height: 0.1, max_obstacle_height: 0.15, observation_persistence: 0.0, obstacle_range: 3.0}
-
-  wall_cloud: {topic: /move_base/clear_wall, sensor_frame: /chest_xtion_depth_optical_frame, data_type: PointCloud2, marking: false, clearing: true, observation_persistence: 0.0, raytrace_range: 2.80}
-  
-  head_cloud_sensor: {topic: /move_base/head_obstacle, data_type: PointCloud2, marking: true, clearing: false, min_obstacle_height: 0.1, max_obstacle_height: 1.1, observation_persistence: 0.0, obstacle_range: 2.0}
-
-  head_clear_sensor: {topic: /move_base/head_clearing, data_type: PointCloud2, marking: false, clearing: true, min_obstacle_height: -0.1, max_obstacle_height: 1.0, observation_persistence: 0.0, raytrace_range: 4.0}
-  
-  head_cliff_sensor: {topic: /move_base/head_cliff, data_type: PointCloud2, marking: true, clearing: false, min_obstacle_height: 0.1, max_obstacle_height: 0.15, observation_persistence: 0.0, obstacle_range: 3.0}
-
-#point_cloud_sensor: {sensor_frame: camera_link, data_type: PointCloud2, topic: /camera/depth/points, marking: true, clearing: true}
 
 
 

--- a/scitos_move_base_params_3d/costmap_common_params.yaml
+++ b/scitos_move_base_params_3d/costmap_common_params.yaml
@@ -30,7 +30,7 @@ head_obstacle_layer:
   unknown_threshold: 9
   mark_threshold: 0
   
-  observation_sources: head_cloud_sensor head_clear_sensor head_cliff_sensor
+  observation_sources: head_cloud_sensor head_clear_sensor
   
   head_cloud_sensor: {topic: /move_base/head_obstacle, data_type: PointCloud2, marking: true, clearing: false, min_obstacle_height: 0.2, max_obstacle_height: 1.3, observation_persistence: 0.0, obstacle_range: 2.0}
 

--- a/scitos_move_base_params_3d/costmap_common_params.yaml
+++ b/scitos_move_base_params_3d/costmap_common_params.yaml
@@ -32,11 +32,11 @@ head_obstacle_layer:
   
   observation_sources: head_cloud_sensor head_clear_sensor head_cliff_sensor
   
-  head_cloud_sensor: {topic: /move_base/head_obstacle, data_type: PointCloud2, marking: true, clearing: false, min_obstacle_height: 0.1, max_obstacle_height: 1.1, observation_persistence: 0.0, obstacle_range: 2.0}
+  head_cloud_sensor: {topic: /move_base/head_obstacle, data_type: PointCloud2, marking: true, clearing: false, min_obstacle_height: 0.2, max_obstacle_height: 1.0, observation_persistence: 0.0, obstacle_range: 2.0}
 
-  head_clear_sensor: {topic: /move_base/head_clearing, data_type: PointCloud2, marking: false, clearing: true, min_obstacle_height: -0.1, max_obstacle_height: 1.0, observation_persistence: 0.0, raytrace_range: 4.0}
+  head_clear_sensor: {topic: /move_base/head_subsampled, data_type: PointCloud2, marking: false, clearing: true, min_obstacle_height: -0.1, max_obstacle_height: 1.1, observation_persistence: 0.0, raytrace_range: 4.0}
   
-  head_cliff_sensor: {topic: /move_base/head_cliff, data_type: PointCloud2, marking: true, clearing: false, min_obstacle_height: 0.1, max_obstacle_height: 0.15, observation_persistence: 0.0, obstacle_range: 3.0}
+#  head_cliff_sensor: {topic: /move_base/head_cliff, data_type: PointCloud2, marking: true, clearing: false, min_obstacle_height: 0.1, max_obstacle_height: 0.15, observation_persistence: 0.0, obstacle_range: 3.0}
   
 obstacle_layer:
   max_obstacle_height: 2.0

--- a/scitos_move_base_params_3d/costmap_common_params.yaml
+++ b/scitos_move_base_params_3d/costmap_common_params.yaml
@@ -21,14 +21,14 @@ inflation_layer:
     
 
 obstacle_layer:
-  max_obstacle_height: 2.0
+  max_obstacle_height: 1.6
   obstacle_range: 2.5
   raytrace_range: 3.0
   
   origin_z: -0.08
   z_resolution: 0.2
-  z_voxels: 6
-  unknown_threshold: 6
+  z_voxels: 9
+  unknown_threshold: 9
   mark_threshold: 0
   
   observation_sources: laser point_cloud_sensor clear_sensor
@@ -40,12 +40,10 @@ obstacle_layer:
   clear_sensor: {topic: /move_base/points_subsampled, data_type: PointCloud2, marking: false, clearing: true, min_obstacle_height: -0.1, max_obstacle_height: 1.1, observation_persistence: 0.0, raytrace_range: 4.0}
 
   wall_cloud: {topic: /move_base/clear_wall, sensor_frame: /chest_xtion_depth_optical_frame, data_type: PointCloud2, marking: false, clearing: true, observation_persistence: 0.0, raytrace_range: 2.80}
-
-
-
   
+  head_cloud_sensor: {topic: /move_base/head_obstacle, data_type: PointCloud2, marking: true, clearing: false, min_obstacle_height: 0.1, max_obstacle_height: 0.9, observation_persistence: 0.0, obstacle_range: 2.0}
 
-
+  head_clear_sensor: {topic: /move_base/head_subsampled, data_type: PointCloud2, marking: false, clearing: true, min_obstacle_height: -0.1, max_obstacle_height: 1.6, observation_persistence: 0.0, raytrace_range: 4.0}
   
 #point_cloud_sensor: {sensor_frame: camera_link, data_type: PointCloud2, topic: /camera/depth/points, marking: true, clearing: true}
 

--- a/scitos_move_base_params_3d/costmap_common_params.yaml
+++ b/scitos_move_base_params_3d/costmap_common_params.yaml
@@ -49,7 +49,7 @@ obstacle_layer:
   unknown_threshold: 6
   mark_threshold: 0
   
-  observation_sources: laser point_cloud_sensor clear_sensor cliff_sensor head_cloud_sensor head_clear_sensor head_cliff_sensor
+  observation_sources: laser point_cloud_sensor clear_sensor cliff_sensor
   
   laser: {sensor_frame: base_laser_link, data_type: LaserScan, topic: scan, marking: true, clearing: true}
   

--- a/scitos_move_base_params_3d/local_costmap_params.yaml
+++ b/scitos_move_base_params_3d/local_costmap_params.yaml
@@ -8,4 +8,5 @@ local_costmap:
   resolution: 0.05
   plugins:  
     - {name: obstacle_layer, type: "costmap_2d::VoxelLayer"}
+    - {name: head_obstacle_layer, type: "costmap_2d::VoxelLayer"}
     - {name: inflation_layer, type: "costmap_2d::InflationLayer"}

--- a/src/remove_edges_cloud.cpp
+++ b/src/remove_edges_cloud.cpp
@@ -46,34 +46,35 @@ int main(int argc, char** argv)
     ros::init(argc, argv, "remove_edges_cloud");
 	ros::NodeHandle n;	
 
+    ros::NodeHandle pn("~");
     // topic of input cloud
-    if (!n.hasParam("/remove_edges_cloud/input")) {
+    if (!pn.hasParam("input")) {
         ROS_ERROR("Could not find parameter input.");
         return -1;
     }
     std::string input;
-    n.getParam("/remove_edges_cloud/input", input);
+    pn.getParam("input", input);
     
     // topic of output cloud
-    if (!n.hasParam("/remove_edges_cloud/output")) {
+    if (!pn.hasParam("output")) {
         ROS_ERROR("Could not find parameter output.");
         return -1;
     }
     std::string output;
-    n.getParam("/remove_edges_cloud/output", output);
+    pn.getParam("output", output);
 
     // how many pixels to cut off in the depth image
-	if (!n.hasParam("/remove_edges_cloud/cutoff")) {
+	if (!pn.hasParam("cutoff")) {
         ROS_ERROR("Could not find parameter cutoff.");
         return -1;
     }
-    n.getParam("/remove_edges_cloud/cutoff", cutoff);
+    pn.getParam("cutoff", cutoff);
     
-    if (!n.hasParam("/remove_edges_cloud/cutoff_z")) {
+    if (!pn.hasParam("cutoff_z")) {
         ROS_ERROR("Could not find parameter cutoff_z.");
         return -1;
     }
-    n.getParam("/remove_edges_cloud/cutoff_z", cutoff_z);
+    pn.getParam("cutoff_z", cutoff_z);
     
 	ros::Subscriber sub = n.subscribe(input, 1, callback);
     pub = n.advertise<sensor_msgs::PointCloud2>(output, 1);


### PR DESCRIPTION
This adds an extra obstacle layer in the local costmap called the head_obstacle_layer. This is done to minimize interference with the rest of the nav stack but comes with one big drawback: The head_obstacle_layer cannot clear the obstacle_layer and vice versa. I have not encountered a problem with this during my experiments since the robot can typically go forward after backing down. Also, at G4S there shouldn't be many dynamic obstacles if I'm not wrong. Otherwise, adding it to the normal costmap could have caused performance issues which I am not so keen on introducing at this point=/. Also, the local costmap gets cleared when the robot is more than 4 meter (or is it 2) meters away.

@BFALacerda Should this go in a G4S deployment branch instead?
