### PR TITLE
Use scitos_2d_navigation's own parameters.

### DIFF
--- a/launch/move_base.launch
+++ b/launch/move_base.launch
@@ -8,7 +8,7 @@
 
 	<node pkg="move_base" type="move_base" respawn="false" name="move_base" output="screen" clear_params="true" unless="$(arg with_mux)">
 		<!-- default:20.0. with this value dwa planner fails to find a valid plan a lot more -->
-        <rosparam file="$(find strands_movebase)/strands_movebase_params/move_base_params.yaml" command="load"/>
+        	<rosparam file="$(find scitos_2d_navigation)/scitos_move_base_params/move_base_params.yaml" command="load"/>
 		<rosparam file="$(find scitos_2d_navigation)/scitos_move_base_params/costmap_common_params.yaml" command="load" ns="global_costmap" />
 		<rosparam file="$(find scitos_2d_navigation)/scitos_move_base_params/costmap_common_params.yaml" command="load" ns="local_costmap" />
 		<rosparam file="$(find scitos_2d_navigation)/scitos_move_base_params/local_costmap_params.yaml" command="load" />
@@ -19,7 +19,7 @@
 	<node pkg="move_base" type="move_base" respawn="false" name="move_base" output="screen" clear_params="true" if="$(arg with_mux)">
 		<!-- default:20.0. with this value dwa planner fails to find a valid plan a lot more -->
         <remap from="/cmd_vel" to="/cmd_vel_mux/input/navigation"/>
-        <rosparam file="$(find strands_movebase)/strands_movebase_params/move_base_params.yaml" command="load"/>
+        	<rosparam file="$(find scitos_2d_navigation)/scitos_move_base_params/move_base_params.yaml" command="load"/>
 		<rosparam file="$(find scitos_2d_navigation)/scitos_move_base_params/costmap_common_params.yaml" command="load" ns="global_costmap" />
 		<rosparam file="$(find scitos_2d_navigation)/scitos_move_base_params/costmap_common_params.yaml" command="load" ns="local_costmap" />
 		<rosparam file="$(find scitos_2d_navigation)/scitos_move_base_params/local_costmap_params.yaml" command="load" />


### PR DESCRIPTION
Switches to use the `scitos_2d_navigation` parameters for move_base instead of linking to the `strands_movebase` copy. I think this is tidier than the alternative of adding a dependency on strands_movebase.
